### PR TITLE
fix(statistics): 修复统计数据显示异常和柱状图空白问题

### DIFF
--- a/backend/src/main/java/com/activityassistant/service/StatisticsService.java
+++ b/backend/src/main/java/com/activityassistant/service/StatisticsService.java
@@ -136,8 +136,18 @@ public class StatisticsService {
         // 3. 统计参与的活动数（已通过报名的）
         long participatedActivities = registrationRepository.countByUserIdAndStatus(targetUserId, "approved");
 
-        // 4. 统计总报名数
-        long totalRegistrations = registrationRepository.countByUserId(targetUserId);
+        // 4. 统计用户创建的活动收到的总报名数
+        // 获取用户创建的所有活动ID
+        List<Activity> createdActivitiesList = activityRepository.findByOrganizerId(targetUserId);
+        List<String> activityIds = createdActivitiesList.stream()
+                .map(Activity::getId)
+                .toList();
+
+        // 统计这些活动的总报名数
+        long totalRegistrations = 0L;
+        for (String activityId : activityIds) {
+            totalRegistrations += registrationRepository.countByActivityId(activityId);
+        }
 
         // 5. 统计总签到数
         long totalCheckins = checkinRepository.countByUserId(targetUserId);

--- a/pages/statistics/created-detail.js
+++ b/pages/statistics/created-detail.js
@@ -153,49 +153,106 @@ Page({
   },
 
   /**
-   * 初始化柱状图 - 每月创建活动趋势
+   * 初始化柱状图 - 每月创建活动趋势（智能动态范围）
    */
   initBarChart() {
-    console.log('📊 [created-detail] 初始化柱状图');
+    console.log('📊 [created-detail] 初始化柱状图（智能动态范围）');
 
     // 从页面数据中获取活动列表
     const userActivities = this.data.activities;
 
     console.log('📋 [柱状图] 找到创建的活动:', userActivities.length, '个');
 
+    // 如果没有数据，跳过初始化
+    if (userActivities.length === 0) {
+      console.log('📊 [柱状图] 无数据，跳过初始化');
+      return;
+    }
+
     // 统计最近6个月的数据
     const now = new Date();
-    const monthData = {};
-    const monthLabels = [];
+    const recentMonthData = {};
+    const recentMonthLabels = [];
 
     // 生成最近6个月的标签
     for (let i = 5; i >= 0; i--) {
       const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
       const month = date.getMonth() + 1;
       const label = `${month}月`;
-      monthLabels.push(label);
-      monthData[label] = 0;
+      recentMonthLabels.push(label);
+      recentMonthData[label] = 0;
     }
 
-    console.log('📅 [柱状图] 月份标签:', monthLabels);
+    console.log('📅 [柱状图] 最近6个月标签:', recentMonthLabels);
 
-    // 统计每月创建活动数
+    // 统计最近6个月的数据
+    let hasDataInRecentMonths = false;
     userActivities.forEach(activity => {
       const createDate = parseDate(activity.createdAt);
       const month = createDate.getMonth() + 1;
       const label = `${month}月`;
-      if (monthData.hasOwnProperty(label)) {
-        monthData[label]++;
+      if (recentMonthData.hasOwnProperty(label)) {
+        recentMonthData[label]++;
+        hasDataInRecentMonths = true;
       }
     });
 
-    console.log('📊 [柱状图] 月度数据:', monthData);
+    console.log('📊 [柱状图] 最近6个月数据:', recentMonthData, '是否有数据:', hasDataInRecentMonths);
 
-    const barData = monthLabels.map(label => monthData[label]);
-    console.log('📊 [柱状图] 图表数据:', barData);
+    // 决定使用哪个时间范围
+    let finalLabels, finalData;
+
+    if (hasDataInRecentMonths) {
+      // 有最近6个月的数据，使用最近6个月
+      finalLabels = recentMonthLabels;
+      finalData = recentMonthLabels.map(label => recentMonthData[label]);
+      console.log('✅ [柱状图] 使用最近6个月数据');
+    } else {
+      // 没有最近6个月的数据，使用数据实际所在的月份
+      console.log('⚠️ [柱状图] 最近6个月无数据，切换到数据实际月份');
+
+      // 提取所有活动的创建月份
+      const allMonths = userActivities.map(activity => {
+        const createDate = parseDate(activity.createdAt);
+        return {
+          year: createDate.getFullYear(),
+          month: createDate.getMonth() + 1,
+          timestamp: createDate.getTime()
+        };
+      });
+
+      // 按时间排序并去重
+      const uniqueMonths = [...new Map(
+        allMonths.map(m => [`${m.year}-${m.month}`, m])
+      ).values()].sort((a, b) => a.timestamp - b.timestamp);
+
+      console.log('📅 [柱状图] 数据实际月份:', uniqueMonths);
+
+      // 取最后6个月（或全部，如果不足6个月）
+      const displayMonths = uniqueMonths.slice(-6);
+      finalLabels = displayMonths.map(m => `${m.month}月`);
+
+      // 统计这些月份的数据
+      const dataMonthData = {};
+      finalLabels.forEach(label => dataMonthData[label] = 0);
+
+      userActivities.forEach(activity => {
+        const createDate = parseDate(activity.createdAt);
+        const month = createDate.getMonth() + 1;
+        const label = `${month}月`;
+        if (dataMonthData.hasOwnProperty(label)) {
+          dataMonthData[label]++;
+        }
+      });
+
+      finalData = finalLabels.map(label => dataMonthData[label]);
+      console.log('✅ [柱状图] 使用数据实际月份:', finalLabels, finalData);
+    }
+
+    console.log('📊 [柱状图] 最终图表数据:', { labels: finalLabels, data: finalData });
 
     // 计算Y轴最大值，向上取整到合适的刻度
-    const maxValue = Math.max(...barData, 1);
+    const maxValue = Math.max(...finalData, 1);
     // 对于少量数据，设置更合理的Y轴范围
     let yMax;
     if (maxValue <= 3) {
@@ -211,10 +268,10 @@ Page({
     barChart = new wxCharts({
       canvasId: 'bar-canvas',
       type: 'column',
-      categories: monthLabels,
+      categories: finalLabels,
       series: [{
         name: '创建活动数',
-        data: barData,
+        data: finalData,
         color: '#10b981'
       }],
       width: this.data.canvasWidth,
@@ -240,6 +297,8 @@ Page({
         }
       }
     });
+
+    console.log('✅ [柱状图] 初始化完成');
   }
 });
 

--- a/pages/statistics/index.js
+++ b/pages/statistics/index.js
@@ -106,6 +106,8 @@ Page({
         ];
 
         // 设置已创建活动的统计数据
+        // 防御性处理：当创建活动数为0时，其他统计项显示空白
+        const hasCreatedActivities = (data.createdActivities || 0) > 0;
         const createdStats = [
           {
             label: '创建活动数',
@@ -116,21 +118,21 @@ Page({
           },
           {
             label: '总报名人数',
-            value: data.totalRegistrations || 0,
+            value: hasCreatedActivities ? (data.totalRegistrations || 0) : '',
             icon: '👥',
             bg: '#dcfce7',
             color: '#047857'
           },
           {
             label: '无效签到',
-            value: data.invalidCheckinCount || 0,
+            value: hasCreatedActivities ? (data.invalidCheckinCount || 0) : '',
             icon: '📈',
             bg: '#fde68a',
             color: '#b45309'
           },
           {
             label: '获得评价数',
-            value: data.totalReviews || 0,
+            value: hasCreatedActivities ? (data.totalReviews || 0) : '',
             icon: '⭐',
             bg: '#ede9fe',
             color: '#6d28d9'

--- a/pages/statistics/joined-detail.js
+++ b/pages/statistics/joined-detail.js
@@ -168,49 +168,106 @@ Page({
   },
 
   /**
-   * 初始化柱状图 - 每月参加活动趋势
+   * 初始化柱状图 - 每月参加活动趋势（智能动态范围）
    */
   initBarChart() {
-    console.log('📊 [joined-detail] 初始化柱状图');
+    console.log('📊 [joined-detail] 初始化柱状图（智能动态范围）');
 
     // 从页面数据中获取报名记录
     const userRegistrations = this.data.registrations;
 
     console.log('📋 [柱状图] 找到报名记录:', userRegistrations.length, '条');
 
+    // 如果没有数据，跳过初始化
+    if (userRegistrations.length === 0) {
+      console.log('📊 [柱状图] 无数据，跳过初始化');
+      return;
+    }
+
     // 统计最近6个月的数据
     const now = new Date();
-    const monthData = {};
-    const monthLabels = [];
+    const recentMonthData = {};
+    const recentMonthLabels = [];
 
     // 生成最近6个月的标签
     for (let i = 5; i >= 0; i--) {
       const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
       const month = date.getMonth() + 1;
       const label = `${month}月`;
-      monthLabels.push(label);
-      monthData[label] = 0;
+      recentMonthLabels.push(label);
+      recentMonthData[label] = 0;
     }
 
-    console.log('📅 [柱状图] 月份标签:', monthLabels);
+    console.log('📅 [柱状图] 最近6个月标签:', recentMonthLabels);
 
-    // 统计每月参加活动数
+    // 统计最近6个月的数据
+    let hasDataInRecentMonths = false;
     userRegistrations.forEach(r => {
       const regDate = parseDate(r.registeredAt || r.createdAt);
       const month = regDate.getMonth() + 1;
       const label = `${month}月`;
-      if (monthData.hasOwnProperty(label)) {
-        monthData[label]++;
+      if (recentMonthData.hasOwnProperty(label)) {
+        recentMonthData[label]++;
+        hasDataInRecentMonths = true;
       }
     });
 
-    console.log('📊 [柱状图] 月度数据:', monthData);
+    console.log('📊 [柱状图] 最近6个月数据:', recentMonthData, '是否有数据:', hasDataInRecentMonths);
 
-    const barData = monthLabels.map(label => monthData[label]);
-    console.log('📊 [柱状图] 图表数据:', barData);
+    // 决定使用哪个时间范围
+    let finalLabels, finalData;
+
+    if (hasDataInRecentMonths) {
+      // 有最近6个月的数据，使用最近6个月
+      finalLabels = recentMonthLabels;
+      finalData = recentMonthLabels.map(label => recentMonthData[label]);
+      console.log('✅ [柱状图] 使用最近6个月数据');
+    } else {
+      // 没有最近6个月的数据，使用数据实际所在的月份
+      console.log('⚠️ [柱状图] 最近6个月无数据，切换到数据实际月份');
+
+      // 提取所有报名的月份
+      const allMonths = userRegistrations.map(r => {
+        const regDate = parseDate(r.registeredAt || r.createdAt);
+        return {
+          year: regDate.getFullYear(),
+          month: regDate.getMonth() + 1,
+          timestamp: regDate.getTime()
+        };
+      });
+
+      // 按时间排序并去重
+      const uniqueMonths = [...new Map(
+        allMonths.map(m => [`${m.year}-${m.month}`, m])
+      ).values()].sort((a, b) => a.timestamp - b.timestamp);
+
+      console.log('📅 [柱状图] 数据实际月份:', uniqueMonths);
+
+      // 取最后6个月（或全部，如果不足6个月）
+      const displayMonths = uniqueMonths.slice(-6);
+      finalLabels = displayMonths.map(m => `${m.month}月`);
+
+      // 统计这些月份的数据
+      const dataMonthData = {};
+      finalLabels.forEach(label => dataMonthData[label] = 0);
+
+      userRegistrations.forEach(r => {
+        const regDate = parseDate(r.registeredAt || r.createdAt);
+        const month = regDate.getMonth() + 1;
+        const label = `${month}月`;
+        if (dataMonthData.hasOwnProperty(label)) {
+          dataMonthData[label]++;
+        }
+      });
+
+      finalData = finalLabels.map(label => dataMonthData[label]);
+      console.log('✅ [柱状图] 使用数据实际月份:', finalLabels, finalData);
+    }
+
+    console.log('📊 [柱状图] 最终图表数据:', { labels: finalLabels, data: finalData });
 
     // 计算Y轴最大值，向上取整到合适的刻度
-    const maxValue = Math.max(...barData, 1);
+    const maxValue = Math.max(...finalData, 1);
     // 对于少量数据，设置更合理的Y轴范围
     let yMax;
     if (maxValue <= 3) {
@@ -226,10 +283,10 @@ Page({
     barChart = new wxCharts({
       canvasId: 'bar-canvas',
       type: 'column',
-      categories: monthLabels,
+      categories: finalLabels,
       series: [{
         name: '参加活动数',
-        data: barData,
+        data: finalData,
         color: '#3b82f6'
       }],
       width: this.data.canvasWidth,
@@ -255,6 +312,8 @@ Page({
         }
       }
     });
+
+    console.log('✅ [柱状图] 初始化完成');
   }
 });
 


### PR DESCRIPTION
## 问题描述

1. 已创建活动统计数据错误：未创建活动的用户"总报名人数"显示异常值
2. 柱状图完全空白：只显示坐标轴，数据柱不显示

## 根本原因

### 问题1：后端统计逻辑错误
- StatisticsService 中 totalRegistrations 统计的是用户作为参与者的报名次数
- 应该统计用户创建的活动收到的总报名数

### 问题2：时间范围限制
- 柱状图固定显示最近6个月数据
- 如果用户数据在其他月份，则被过滤导致空白

## 修复内容

### 后端修复
- 修正 StatisticsService.getUserStatistics() 的统计逻辑
- 统计用户创建的所有活动收到的总报名数

### 前端修复
- 数据统计页面：添加防御性处理，创建活动数为0时其他统计项显示空白
- 柱状图：实现智能动态范围
  * 优先显示最近6个月数据
  * 如果最近6个月无数据，自动切换到数据实际所在的月份
  * 添加详细的调试日志

## 影响范围

- 后端：StatisticsService.java
- 前端：pages/statistics/index.js, joined-detail.js, created-detail.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)